### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/wurstmineberg_web/views.py
+++ b/wurstmineberg_web/views.py
@@ -20,9 +20,9 @@ def index():
     if main_world.is_running:
         version = main_world.version
         if version is None:
-            version_url = 'https://minecraft.fandom.com/wiki/Version_history'
+            version_url = 'https://minecraft.wiki/w/Version_history'
         else:
-            version_url = f'https://minecraft.fandom.com/wiki/Java_Edition_{urllib.parse.quote(version)}'
+            version_url = f'https://minecraft.wiki/w/Java_Edition_{urllib.parse.quote(version)}'
         return {
             'running': True,
             'version': version,


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki